### PR TITLE
Update ARDiscoveryBLEDiscoveryImpl.java due to nullpointer exception on some devices that do not have BLE but report incorrectly that they do. 

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,6 +4,9 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+
     <uses-sdk
         android:minSdkVersion="14"
         android:targetSdkVersion="19" />

--- a/JNI/java/com/parrot/arsdk/ardiscovery/ARDiscoveryBLEDiscoveryImpl.java
+++ b/JNI/java/com/parrot/arsdk/ardiscovery/ARDiscoveryBLEDiscoveryImpl.java
@@ -250,18 +250,26 @@ public class ARDiscoveryBLEDiscoveryImpl implements ARDiscoveryBLEDiscovery
         }
         else
         {
-            ARSALPrint.d(TAG,"BLE Is Available");
-            bleIsAvailable = true;
+            /* Attempt to initialize Bluetooth adapter. */
+            final BluetoothManager bluetoothManager = (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+            bluetoothAdapter = bluetoothManager.getAdapter();
+            
+            if (bluetoothAdapter == null)
+            {
+                ARSALPrint.d(TAG,"BLE Is NOT Available");
+                bleIsAvailable = false;
+            }
+            else 
+            {
+                ARSALPrint.d(TAG,"BLE Is Available");
+                bleIsAvailable = true;
+            }
         }
     }
 
     @TargetApi(18)
     private void initBLE()
     {
-        /* Initializes Bluetooth adapter. */
-        final BluetoothManager bluetoothManager = (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
-        bluetoothAdapter = bluetoothManager.getAdapter();
-
         bleScanner = new BLEScanner();
 
         leScanCallback = new BluetoothAdapter.LeScanCallback()

--- a/JNI/java/com/parrot/arsdk/ardiscovery/ARDiscoveryMdnsSdMinDiscovery.java
+++ b/JNI/java/com/parrot/arsdk/ardiscovery/ARDiscoveryMdnsSdMinDiscovery.java
@@ -38,6 +38,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
+import android.os.Bundle;
 
 import com.parrot.arsdk.ardiscovery.mdnssdmin.MdnsSdMin;
 import com.parrot.arsdk.arsal.ARSALPrint;
@@ -50,7 +51,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import android.os.Bundle;
 
 /**
  * Custom mdns-sd implementation of the wifi part of ARDiscoveryService
@@ -162,7 +162,7 @@ public class ARDiscoveryMdnsSdMinDiscovery implements ARDiscoveryWifiDiscovery
                 ARSALPrint.d(TAG, "Receive CONNECTIVITY_ACTION intent, extras are :");
                 Bundle extras = intent.getExtras();
                 for (String key : extras.keySet()) {
-                    ARSALPrint.d(TAG, "Key : " + key + ", value = " + extras.get(key).toString());
+                    ARSALPrint.d(TAG, "Key : " + key + ", value = " + (extras.get(key) != null ? extras.get(key).toString() : "NULL"));
                 }
                 ARSALPrint.d(TAG, "End of extras");
 

--- a/libARDiscovery.iml
+++ b/libARDiscovery.iml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id=":libARDiscovery" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/../../../ARPro3" external.system.id="GRADLE" external.system.module.group="ARPro3" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android-gradle" name="Android-Gradle">
+      <configuration>
+        <option name="GRADLE_PROJECT_PATH" value=":libARDiscovery" />
+      </configuration>
+    </facet>
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="SELECTED_BUILD_VARIANT" value="release" />
+        <option name="SELECTED_TEST_ARTIFACT" value="_unit_test_" />
+        <option name="ASSEMBLE_TASK_NAME" value="assembleRelease" />
+        <option name="COMPILE_JAVA_TASK_NAME" value="compileReleaseSources" />
+        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleReleaseUnitTest" />
+        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileReleaseUnitTestSources" />
+        <afterSyncTasks>
+          <task>generateReleaseSources</task>
+          <task>mockableAndroidJar</task>
+          <task>prepareReleaseUnitTestDependencies</task>
+        </afterSyncTasks>
+        <option name="ALLOW_USER_CONFIGURATION" value="false" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/src/main/assets" />
+        <option name="LIBRARY_PROJECT" value="true" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/classes/release" />
+    <output-test url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/classes/test/release" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery">
+      <sourceFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/generated/source/r/release" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/generated/source/aidl/release" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/generated/source/buildConfig/release" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/generated/source/rs/release" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/generated/res/rs/release" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/generated/res/resValues/release" type="java-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/annotations" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/bundles" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/classes" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/dependency-cache" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/jniLibs" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/lint" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/res" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/intermediates/transforms" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../ARPro3/build/libARDiscovery/tmp" />
+    </content>
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/release/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/release/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/release/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/release/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/release/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/release/jni" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/release/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testRelease/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testRelease/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testRelease/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testRelease/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testRelease/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testRelease/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testRelease/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/JNI/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/gen/JNI/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+    </content>
+    <orderEntry type="jdk" jdkName="Android API 23 Platform (1)" jdkType="Android SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" exported="" name="support-v4-23.1.1" level="project" />
+    <orderEntry type="library" exported="" name="sanselan-0.97-incubator" level="project" />
+    <orderEntry type="library" exported="" name="jmdns-3.4.1" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.1.1" level="project" />
+    <orderEntry type="module" module-name="libARSAL" exported="" />
+  </component>
+</module>


### PR DESCRIPTION
Cannot rely on getPackageManager().hasSystemFeature() for validating presence of BLE as some devices incorrectly set this feature even though they do not support BLE.
